### PR TITLE
adding a forwarding feature to a Logs Data Platform endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Parameters
 * Forwarding
   * `forwardURL` The Logs Data Platform GELF Input URL to forward logs to. ldp-tail can forward matching logs to another Logs Data Platform instance by using the URL of the SSL GELF Input. 
   * `forwardToken` The token of the stream you forward logs to. Using a generic input ask you to specify the token of the stream you want to send logs to.  
+  * `silent` Disable the print of messages when forwarding. When forwarding is enabled, you can use this option to not display the messages ldp-tail forwards. 
 * Config
   * `config` Config file loaded before parsing parameters, so parameters will override the values in the config file (except for `match` where parameters will add more criteria instead of replacing them). The config file use the [TOML](https://github.com/toml-lang/toml) file format. The structure of the configuration file is:
 ```

--- a/README.md
+++ b/README.md
@@ -55,10 +55,15 @@ Parameters
     * `begin` Return true if the first argument begins with the second
     * `contain` Return true if the second argument is within the first
     * `level` Transform a Gelf/Syslog level value (0-7) to a syslog severity keyword
+* Forwarding
+  * `forwardURL` The Logs Data Platform GELF Input URL to forward logs to. ldp-tail can forward matching logs to another Logs Data Platform instance by using the URL of the SSL GELF Input. 
+  * `forwardToken` The token of the stream you forward logs to. Using a generic input ask you to specify the token of the stream you want to send logs to.  
 * Config
   * `config` Config file loaded before parsing parameters, so parameters will override the values in the config file (except for `match` where parameters will add more criteria instead of replacing them). The config file use the [TOML](https://github.com/toml-lang/toml) file format. The structure of the configuration file is:
 ```
 Address string
+ForwardURL string
+ForwardToken string
 Match   []{
     Key      string
     Operator string
@@ -71,6 +76,8 @@ Raw     bool
 Exemple:
 ```
 Address = "wss://gra1.logs.ovh.com/tail/?tk=demo"
+ForwardURL = "gra2.logs.ovh.com:12202"
+ForwardToken = "7489e9b1-8f86-43a2-c9af-0b878687a364"
 Pattern = "{{date .timestamp}}: {{if ne ._title \"\"}}[ {{._title}} ] {{end}}{{ .short_message }}"
 ```
 

--- a/conf.go
+++ b/conf.go
@@ -17,6 +17,7 @@ type conf struct {
 	Match        []matchCriterion
 	Pattern      string
 	Raw          bool
+	Silent       bool
 }
 
 var defaultConf = conf{
@@ -25,6 +26,7 @@ var defaultConf = conf{
 	"",
 	nil,
 	"{{._appID}}> {{.short_message}}",
+	false,
 	false,
 }
 
@@ -40,6 +42,7 @@ func getConf() conf {
 	match := flag.StringArray("match", nil, "Fields to match")
 	pattern := flag.String("pattern", defaultConf.Pattern, "Template to apply on each message to display it")
 	raw := flag.Bool("raw", defaultConf.Raw, "Display raw message instead of parsing it")
+	silent := flag.Bool("silent", defaultConf.Silent, "Do not display messages when forwarding")
 
 	flag.Parse()
 
@@ -78,6 +81,10 @@ func getConf() conf {
 	}
 	if *raw != defaultConf.Raw {
 		c.Raw = *raw
+	}
+
+	if *silent != defaultConf.Silent {
+		c.Silent = *silent
 	}
 
 	// Match Criteria

--- a/conf.go
+++ b/conf.go
@@ -11,13 +11,17 @@ import (
 )
 
 type conf struct {
-	Address string
-	Match   []matchCriterion
-	Pattern string
-	Raw     bool
+	Address      string
+	ForwardURL   string
+	ForwardToken string
+	Match        []matchCriterion
+	Pattern      string
+	Raw          bool
 }
 
 var defaultConf = conf{
+	"",
+	"",
 	"",
 	nil,
 	"{{._appID}}> {{.short_message}}",
@@ -31,6 +35,8 @@ func getConf() conf {
 	configFile := flag.String("config", "", "Configuration file")
 
 	address := flag.String("address", defaultConf.Address, "URI of the websocket")
+	forwardURL := flag.String("forwardURL", "", "Logs Data Platform URL to forward logs to")
+	forwardToken := flag.String("forwardToken", "", "Logs Data Platform Token of the stream you forward logs to")
 	match := flag.StringArray("match", nil, "Fields to match")
 	pattern := flag.String("pattern", defaultConf.Pattern, "Template to apply on each message to display it")
 	raw := flag.Bool("raw", defaultConf.Raw, "Display raw message instead of parsing it")
@@ -51,6 +57,22 @@ func getConf() conf {
 	if *address != defaultConf.Address {
 		c.Address = *address
 	}
+	if *forwardURL != "" {
+		if *forwardToken == "" {
+			log.Fatal("a forward URL must be associated with a forward Token")
+		} else {
+			c.ForwardURL = *forwardURL
+		}
+	}
+
+	if *forwardToken != "" {
+		if *forwardURL == "" {
+			log.Fatal("a forward Token must be associated with a forward URL")
+		} else {
+			c.ForwardToken = *forwardToken
+		}
+	}
+
 	if *pattern != defaultConf.Pattern {
 		c.Pattern = *pattern
 	}

--- a/forwarder.go
+++ b/forwarder.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"log"
+	"strings"
+)
+
+func forwardToLDP(messageChan <-chan map[string]interface{}, ldpURL string, forwardToken string) {
+	conn, err := tls.Dial("tcp", ldpURL, &tls.Config{})
+	if err != nil {
+		panic("failed to Connect")
+	}
+	defer conn.Close()
+
+	for {
+		message := <-messageChan
+		//replace X-OVH-TOKEN
+		for k, _ := range message {
+			if strings.HasPrefix(k, "_X-OVH-TOKEN") {
+				delete(message, k)
+			}
+		}
+		message["_X-OVH-TOKEN"] = forwardToken
+		data, err := json.Marshal(&message)
+		data = append(data, byte(0))
+		sent, err := conn.Write(data)
+		if sent < len(data) || err != nil {
+			log.Fatal(err)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -66,6 +66,14 @@ func main() {
 
 		}
 	}
+	var messageChannel chan map[string]interface{}
+	forwardEnabled := false
+
+	if c.ForwardURL != "" && c.ForwardToken != "" {
+		messageChannel = make(chan map[string]interface{}, 100)
+		go forwardToLDP(messageChannel, c.ForwardURL, c.ForwardToken)
+		forwardEnabled = true
+	}
 
 	for {
 		// Try to connect
@@ -118,6 +126,10 @@ func main() {
 				if err != nil {
 					log.Printf("Error while executing template: %s", err.Error())
 				}
+			}
+
+			if forwardEnabled {
+				messageChannel <- message
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -68,11 +68,15 @@ func main() {
 	}
 	var messageChannel chan map[string]interface{}
 	forwardEnabled := false
+	silent := false
 
 	if c.ForwardURL != "" && c.ForwardToken != "" {
 		messageChannel = make(chan map[string]interface{}, 100)
 		go forwardToLDP(messageChannel, c.ForwardURL, c.ForwardToken)
 		forwardEnabled = true
+		if c.Silent {
+			silent = true
+		}
 	}
 
 	for {
@@ -85,6 +89,10 @@ func main() {
 		}
 
 		log.Println("Connected!")
+
+		if silent {
+			log.Println("Forwarding in silent mode")
+		}
 
 		var msg []byte
 		for {
@@ -117,14 +125,16 @@ func main() {
 				continue
 			}
 
-			if c.Raw {
-				fmt.Printf("%+v\n", message)
-			} else {
-				// Print them
-				err = t.Execute(os.Stdout, message)
-				os.Stdout.Write([]byte{'\n'})
-				if err != nil {
-					log.Printf("Error while executing template: %s", err.Error())
+			if !silent {
+				if c.Raw {
+					fmt.Printf("%+v\n", message)
+				} else {
+					// Print them
+					err = t.Execute(os.Stdout, message)
+					os.Stdout.Write([]byte{'\n'})
+					if err != nil {
+						log.Printf("Error while executing template: %s", err.Error())
+					}
 				}
 			}
 


### PR DESCRIPTION
Hello, 
I would like to add a forwarding feature to this tool to provide a way for users to forward Logs from an instance of Logs Data Platform to another instance. ldp-tail is a convenient way to do that. Note that to there is no re-send policy, a failure on the forward process will issue a fatal log. 

Signed-off-by: Babacar Diassé <babacar.diasse@corp.ovh.com>